### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ ___
 
 We kept the requirements for Red Wizard as simple as possible:
 
-* Ubuntu 22.04 on the deployment system (Your laptop or a VM is fine)
+* Ubuntu 22.04 on the deployment system (Your laptop or a VM is fine) with a 16G root partition. 
 * Clean Ubuntu 20.04 on all target machines (Will support 22.04 in the near future)
 * 1 deployment user (Configured for key-based SSH access on all machines)
 * Deployment user has identical sudo password on all machines


### PR DESCRIPTION
The current C2 backend requires a larger root partition to build/run docker containers. Instructions on this would be helpful and save people time. 

As an example on an EC2 T2 Micro, with an 8 gig portion, I ran out of disk space during Ansible orchestration.